### PR TITLE
Add support for query aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ sqleton is a tool to easily run SQL commands.
 
 - easily make a self-contained CLI to interact with your application
 - extend the CLI application with your own repository of commands
+  - create aliases for existing commands to save flag presets
 - rich data format output thanks to [glazed](https://github.com/wesen/glazed)
 - rich help system courtesy of [glazed](https://github.com/wesen/glazed)
     - easily add documentation to your CLI by editing markdown files
@@ -113,4 +114,4 @@ all you need to do is add a markdown file in the doc/ directory!
 ```
 
 It makes heavy use of my [glazed](https://github.com/wesen/glazed) library,
-and in many ways is a test-driver for its development
+and in many ways is a test-driver for its development presets

--- a/cmd/sqleton/cmds/queries.go
+++ b/cmd/sqleton/cmds/queries.go
@@ -8,7 +8,7 @@ import (
 	sqleton "github.com/wesen/sqleton/pkg"
 )
 
-func AddQueriesCmd(allQueries []*sqleton.SqlCommand) *cobra.Command {
+func AddQueriesCmd(allQueries []*sqleton.SqlCommand, aliases []*sqleton.CommandAlias) *cobra.Command {
 	var queriesCmd = &cobra.Command{
 		Use:   "queries",
 		Short: "Commands related to sqleton queries",
@@ -29,6 +29,18 @@ func AddQueriesCmd(allQueries []*sqleton.SqlCommand) *cobra.Command {
 					"long":   query.Long,
 					"query":  query.Query,
 					"source": query.Source,
+				}
+				err := gp.ProcessInputObject(obj)
+				if err != nil {
+					return errors.Wrapf(err, "Could not process input object")
+				}
+			}
+
+			for _, alias := range aliases {
+				obj := map[string]interface{}{
+					"name":     alias.Name,
+					"aliasFor": alias.AliasFor,
+					"source":   alias.Source,
 				}
 				err := gp.ProcessInputObject(obj)
 				if err != nil {

--- a/cmd/sqleton/doc/topics/04-aliases.md
+++ b/cmd/sqleton/doc/topics/04-aliases.md
@@ -1,0 +1,68 @@
+---
+Title: Creating aliases
+Slug: creating-aliases
+Short: |
+   You can add quickly create aliases for existing commands in order
+   to save flags. These aliases can be stored alongside the query files
+   and will become accessible as their own full-fledged cobra commands.
+Topics:
+- queries
+- aliases
+Commands:
+- queries
+Flags:
+- create-alias
+IsTemplate: false
+IsTopLevel: true
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+## Creating aliases
+
+Due to the very flexible glazed output system and the flags available for each command,
+it is useful to be able to create aliases to save on typing and having to remember
+all variations. 
+
+An alias is just a yaml file stored along the query yaml definition. Aliases can be 
+located in an `embed.FS` repository, or in a filesystem repository. 
+
+For a query `ttc/wp/posts.yaml`, aliases can be stored in the directory `ttc/wp/posts/`.
+
+For example, we could have the following alias to show the newest drafts, 
+in `newest-drafts.yaml`:
+
+```yaml
+name: newest-drafts
+aliasFor: posts
+flags:
+  limit: 10
+  from: last week
+  status: draft
+  filter: post_status,post_type
+```
+
+This command can then be executed by running `sqleton ttc wp posts newest-drafts`,
+and will be equivalent to running 
+
+```
+sqleton ttc wp posts --limit 10 --from "last week" \
+   --status draft --filter post_status,post_type
+```
+
+In order to help with the arduous task of writing YAML file, you can 
+automatically emit the alias file by using the `--create-alias [name]` flag:
+
+```
+❯ sqleton wp postmeta --key-like 'refund_reason' --db ttc_prod --order-by "post_id DESC" --create-alias refunds                  
+Flag db changed to ttc_prod
+Flag key-like changed to refund_reason
+Flag order-by changed to post_id DESC
+name: refunds
+aliasFor: postmeta
+flags:
+    db: ttc_prod
+    key-like: refund_reason
+    order-by: post_id DESC
+```
+

--- a/cmd/sqleton/main.go
+++ b/cmd/sqleton/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"embed"
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -160,7 +161,8 @@ func init() {
 	cmds.InitializeMysqlCmd(queriesFS, helpSystem)
 	commands, aliases, err := initCommands(rootCmd)
 	if err != nil {
-		panic(err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error initializing commands: %s\n", err)
+		os.Exit(1)
 	}
 
 	queriesCmd := cmds.AddQueriesCmd(commands, aliases)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tj/go-naturaldate v1.3.0
@@ -47,7 +48,6 @@ require (
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/yuin/goldmark v1.5.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect

--- a/pkg/alias.go
+++ b/pkg/alias.go
@@ -73,6 +73,22 @@ func (a *CommandAlias) Description() SqletonCommandDescription {
 		newArgument := argument.Copy()
 		// TODO(2022-12-22, manuel) this needs to be handled, overriding arguments and figuring out which order
 		// is a bitch
+		//
+		// so iN command.go in cobra, prerun is run before the arg validation is done
+		// so that we could potentially override the args here
+		//
+		// the args are gotten from c.Flags().Args()
+		//
+		// it looks like in prerun, we could check if args is empty,
+		// and if so, pass in our arguments  by calling Parse() a second time,
+		// and then going over the newly set arg?
+		//
+		// It's of course going to be relying on cobra internals a bit,
+		// by assuming that calling parse a second time is not going to interfere with already set flags
+		// so maybe the best solution is really just to interleave the flags at the outset
+		// by doing our own little scanning, which is probably useful anyway if done in glazed
+		// so that we can handle different types of arg parsing.
+		//
 		//if defaultValue, ok := a.ArgumentDefaults[argument.Name]; ok {
 		//	newArgument.Default = defaultValue
 		//}

--- a/pkg/alias.go
+++ b/pkg/alias.go
@@ -1,16 +1,10 @@
 package pkg
 
-import (
-	"context"
-	"github.com/jmoiron/sqlx"
-	"github.com/wesen/glazed/pkg/cli"
-)
-
 type CommandAlias struct {
-	Name             string                 `yaml:"name"`
-	AliasFor         string                 `yaml:"aliasFor"`
-	FlagDefaults     map[string]interface{} `yaml:"flagDefaults,omitempty"`
-	ArgumentDefaults map[string]interface{} `yaml:"argumentDefaults,omitempty"`
+	Name      string            `yaml:"name"`
+	AliasFor  string            `yaml:"aliasFor"`
+	Flags     map[string]string `yaml:"flags,omitempty"`
+	Arguments []string          `yaml:"arguments,omitempty"`
 
 	AliasedCommand SqletonCommand `yaml:",omitempty"`
 	Parents        []string       `yaml:",omitempty"`
@@ -21,16 +15,44 @@ func (a *CommandAlias) IsValid() bool {
 	return a.Name != "" && a.AliasFor != ""
 }
 
-func (a *CommandAlias) RunQueryIntoGlaze(ctx context.Context, db *sqlx.DB, parameters map[string]interface{}, gp *cli.GlazeProcessor) error {
-	return a.AliasedCommand.RunQueryIntoGlaze(ctx, db, parameters, gp)
-}
-
-func (a *CommandAlias) RenderQuery(parameters map[string]interface{}) (string, error) {
-	return a.AliasedCommand.RenderQuery(parameters)
-}
-
 // TODO(2022-12-22, manuel) this is actually not enough, because we want aliases to also deal with
 // any kind of default value. So this is a good first approach, but not sufficient...
+//
+// So what we want to do is to load all the flags and arguments from the alias file
+// and then merge them with the flags and arguments that the user passes on the command line?
+//
+// I'm going to take a look at the implementation of ParseFlags() in cobra. One reason
+// that we need a bit more is because we don't want to use the default value from the aliased commands
+// in case our flags provide something. Maybe cobra allows us to set the flag values?
+//
+// So there is a Set(name,value string) method on the FlagSet. We could use that to set the values
+// as a string, but since we already have them parsed out, that's a bit crude maybe (?)
+//
+// While readin the code I came across the Flag struct which has the following members, maybe there is
+// something useful i can think of while looking through it (plus, remember we wanted to tackle
+// proper flag groups).
+//
+// The flag has something called a Value which is of type Value as well.
+// The DefValue is just a string, used for the usage message.
+// The Changed value specifies if the user overrode the value (this could maybe be useful for
+//     us too because that's what we want to output in the alias file)
+// Deprecated is cool
+// I'm not sure what NoOptDefVal is for, it's the default value if the flag is specified without any option on the command line
+//   so maybe that's a way to give something you can toggle a different default value
+// Annotations is something used by the autocomplete code, which I haven't looked into yet at all
+//
+// Value is an interface that you can Set from a string, that returns its type, and that you can also
+// serialize to a string.
+//
+// If I look at how thisi sno concretely implement, for example by looking at the GetString() method,
+// we can see taht we furst  get the flag type with `getFlagType`, which interestingly returns an interface
+// and takes a conversion function. This first looks up the flag in the flag set, checks that its type
+// matches, then gets its string value, and calls the conversion function.
+// So maybe it's the best for us to also transform everything into a string and just call Set on the flag if
+// it has not been set yet?
+//
+// Let's first start by outputting all the set flags when create-alias is passed.
+
 func (a *CommandAlias) Description() SqletonCommandDescription {
 	s := a.AliasedCommand.Description()
 	ret := SqletonCommandDescription{
@@ -43,19 +65,18 @@ func (a *CommandAlias) Description() SqletonCommandDescription {
 
 	for _, flag := range s.Flags {
 		newFlag := flag.Copy()
-		if defaultValue, ok := a.FlagDefaults[flag.Name]; ok {
-			newFlag.Default = defaultValue
-		}
-		newFlag.Required = false
+		//newFlag.Required = false
 		ret.Flags = append(ret.Flags, newFlag)
 	}
 
 	for _, argument := range s.Arguments {
 		newArgument := argument.Copy()
-		if defaultValue, ok := a.ArgumentDefaults[argument.Name]; ok {
-			newArgument.Default = defaultValue
-		}
-		newArgument.Required = false
+		// TODO(2022-12-22, manuel) this needs to be handled, overriding arguments and figuring out which order
+		// is a bitch
+		//if defaultValue, ok := a.ArgumentDefaults[argument.Name]; ok {
+		//	newArgument.Default = defaultValue
+		//}
+		//newArgument.Required = false
 		ret.Arguments = append(ret.Arguments, newArgument)
 	}
 

--- a/pkg/alias.go
+++ b/pkg/alias.go
@@ -7,14 +7,14 @@ import (
 )
 
 type CommandAlias struct {
-	AliasedCommand   SqletonCommand
 	Name             string                 `yaml:"name"`
 	AliasFor         string                 `yaml:"aliasFor"`
-	FlagDefaults     map[string]interface{} `yaml:"flagDefaults"`
-	ArgumentDefaults map[string]interface{} `yaml:"argumentDefaults"`
+	FlagDefaults     map[string]interface{} `yaml:"flagDefaults,omitempty"`
+	ArgumentDefaults map[string]interface{} `yaml:"argumentDefaults,omitempty"`
 
-	Parents []string
-	Source  string
+	AliasedCommand SqletonCommand `yaml:",omitempty"`
+	Parents        []string       `yaml:",omitempty"`
+	Source         string         `yaml:",omitempty"`
 }
 
 func (a *CommandAlias) IsValid() bool {

--- a/pkg/alias.go
+++ b/pkg/alias.go
@@ -1,0 +1,63 @@
+package pkg
+
+import (
+	"context"
+	"github.com/jmoiron/sqlx"
+	"github.com/wesen/glazed/pkg/cli"
+)
+
+type CommandAlias struct {
+	AliasedCommand   SqletonCommand
+	Name             string                 `yaml:"name"`
+	AliasFor         string                 `yaml:"aliasFor"`
+	FlagDefaults     map[string]interface{} `yaml:"flagDefaults"`
+	ArgumentDefaults map[string]interface{} `yaml:"argumentDefaults"`
+
+	Parents []string
+	Source  string
+}
+
+func (a *CommandAlias) IsValid() bool {
+	return a.Name != "" && a.AliasFor != ""
+}
+
+func (a *CommandAlias) RunQueryIntoGlaze(ctx context.Context, db *sqlx.DB, parameters map[string]interface{}, gp *cli.GlazeProcessor) error {
+	return a.AliasedCommand.RunQueryIntoGlaze(ctx, db, parameters, gp)
+}
+
+func (a *CommandAlias) RenderQuery(parameters map[string]interface{}) (string, error) {
+	return a.AliasedCommand.RenderQuery(parameters)
+}
+
+// TODO(2022-12-22, manuel) this is actually not enough, because we want aliases to also deal with
+// any kind of default value. So this is a good first approach, but not sufficient...
+func (a *CommandAlias) Description() SqletonCommandDescription {
+	s := a.AliasedCommand.Description()
+	ret := SqletonCommandDescription{
+		Name:      a.Name,
+		Short:     s.Short,
+		Long:      s.Long,
+		Flags:     []*SqlParameter{},
+		Arguments: []*SqlParameter{},
+	}
+
+	for _, flag := range s.Flags {
+		newFlag := flag.Copy()
+		if defaultValue, ok := a.FlagDefaults[flag.Name]; ok {
+			newFlag.Default = defaultValue
+		}
+		newFlag.Required = false
+		ret.Flags = append(ret.Flags, newFlag)
+	}
+
+	for _, argument := range s.Arguments {
+		newArgument := argument.Copy()
+		if defaultValue, ok := a.ArgumentDefaults[argument.Name]; ok {
+			newArgument.Default = defaultValue
+		}
+		newArgument.Required = false
+		ret.Arguments = append(ret.Arguments, newArgument)
+	}
+
+	return ret
+}

--- a/pkg/cobra_test.go
+++ b/pkg/cobra_test.go
@@ -36,15 +36,15 @@ func TestAddSingleRequiredArgument(t *testing.T) {
 	assert.Error(t, cmd.Args(cmd, []string{}))
 	assert.Error(t, cmd.Args(cmd, []string{"bar", "foo"}))
 
-	values, err := gatherArguments([]string{"bar"}, desc.Arguments)
+	values, err := gatherArguments([]string{"bar"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(values))
 	assert.Equal(t, "bar", values["foo"])
 
-	_, err = gatherArguments([]string{}, desc.Arguments)
+	_, err = gatherArguments([]string{}, desc.Arguments, false)
 	assert.Error(t, err)
 
-	_, err = gatherArguments([]string{"foo", "bla"}, desc.Arguments)
+	_, err = gatherArguments([]string{"foo", "bla"}, desc.Arguments, false)
 	assert.Error(t, err)
 }
 
@@ -71,19 +71,19 @@ func TestAddTwoRequiredArguments(t *testing.T) {
 	assert.Error(t, cmd.Args(cmd, []string{"bar"}))
 	assert.Error(t, cmd.Args(cmd, []string{"bar", "foo", "baz"}))
 
-	values, err := gatherArguments([]string{"bar", "foo"}, desc.Arguments)
+	values, err := gatherArguments([]string{"bar", "foo"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(values))
 	assert.Equal(t, "bar", values["foo"])
 	assert.Equal(t, "foo", values["bar"])
 
-	_, err = gatherArguments([]string{}, desc.Arguments)
+	_, err = gatherArguments([]string{}, desc.Arguments, false)
 	assert.Error(t, err)
 
-	_, err = gatherArguments([]string{"bar"}, desc.Arguments)
+	_, err = gatherArguments([]string{"bar"}, desc.Arguments, false)
 	assert.Error(t, err)
 
-	_, err = gatherArguments([]string{"bar", "foo", "baz"}, desc.Arguments)
+	_, err = gatherArguments([]string{"bar", "foo", "baz"}, desc.Arguments, false)
 	assert.Error(t, err)
 }
 
@@ -110,22 +110,22 @@ func TestOneRequiredOneOptionalArgument(t *testing.T) {
 	assert.Error(t, cmd.Args(cmd, []string{}))
 	assert.Error(t, cmd.Args(cmd, []string{"bar", "foo", "baz"}))
 
-	values, err := gatherArguments([]string{"bar", "foo"}, desc.Arguments)
+	values, err := gatherArguments([]string{"bar", "foo"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(values))
 	assert.Equal(t, "bar", values["foo"])
 	assert.Equal(t, "foo", values["bar"])
 
-	values, err = gatherArguments([]string{"foo"}, desc.Arguments)
+	values, err = gatherArguments([]string{"foo"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(values))
 	assert.Equal(t, "foo", values["foo"])
 	assert.Equal(t, "baz", values["bar"])
 
-	_, err = gatherArguments([]string{}, desc.Arguments)
+	_, err = gatherArguments([]string{}, desc.Arguments, false)
 	assert.Error(t, err)
 
-	_, err = gatherArguments([]string{"bar", "foo", "baz"}, desc.Arguments)
+	_, err = gatherArguments([]string{"bar", "foo", "baz"}, desc.Arguments, false)
 	assert.Error(t, err)
 }
 
@@ -146,12 +146,12 @@ func TestOneOptionalArgument(t *testing.T) {
 	assert.Nil(t, cmd.Args(cmd, []string{"foo"}))
 	assert.Nil(t, cmd.Args(cmd, []string{}))
 
-	values, err := gatherArguments([]string{"foo"}, desc.Arguments)
+	values, err := gatherArguments([]string{"foo"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(values))
 	assert.Equal(t, "foo", values["foo"])
 
-	values, err = gatherArguments([]string{}, desc.Arguments)
+	values, err = gatherArguments([]string{}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(values))
 	assert.Equal(t, "123", values["foo"])
@@ -170,17 +170,17 @@ func TestDefaultIntValue(t *testing.T) {
 	}
 	err := addArguments(cmd, &desc)
 	require.Nil(t, err)
-	values, err := gatherArguments([]string{}, desc.Arguments)
+	values, err := gatherArguments([]string{}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(values))
 	assert.Equal(t, 123, values["foo"])
 
-	values, err = gatherArguments([]string{"234"}, desc.Arguments)
+	values, err = gatherArguments([]string{"234"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(values))
 	assert.Equal(t, 234, values["foo"])
 
-	_, err = gatherArguments([]string{"foo"}, desc.Arguments)
+	_, err = gatherArguments([]string{"foo"}, desc.Arguments, false)
 	assert.Error(t, err)
 }
 
@@ -326,15 +326,15 @@ func TestAddStringListOptionalArgument(t *testing.T) {
 	assert.Nil(t, cmd.Args(cmd, []string{"foo"}))
 	assert.Nil(t, cmd.Args(cmd, []string{}))
 
-	values, err := gatherArguments([]string{"bar", "foo"}, desc.Arguments)
+	values, err := gatherArguments([]string{"bar", "foo"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, []string{"bar", "foo"}, values["foo"])
 
-	values, err = gatherArguments([]string{"foo"}, desc.Arguments)
+	values, err = gatherArguments([]string{"foo"}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, []string{"foo"}, values["foo"])
 
-	values, err = gatherArguments([]string{}, desc.Arguments)
+	values, err = gatherArguments([]string{}, desc.Arguments, false)
 	require.Nil(t, err)
 	assert.Equal(t, []string{"baz"}, values["foo"])
 }
@@ -535,11 +535,11 @@ func testCommandParseHelper(t *testing.T, desc SqletonCommandDescription, expect
 
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
-			flagParameters, flagsError = gatherFlags(cmd, desc.Flags)
+			flagParameters, flagsError = gatherFlags(cmd, desc.Flags, false)
 			if flagsError != nil {
 				return
 			}
-			argumentParameters, argsError = gatherArguments(args, desc.Arguments)
+			argumentParameters, argsError = gatherArguments(args, desc.Arguments, false)
 			if argsError != nil {
 				return
 			}

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -190,6 +190,14 @@ func sqlIn(values []interface{}) string {
 	return strings.Join(strValues, ",")
 }
 
+func sqlIntIn(values []int) string {
+	strValues := make([]string, len(values))
+	for i, v := range values {
+		strValues[i] = fmt.Sprintf("%d", v)
+	}
+	return strings.Join(strValues, ",")
+}
+
 func sqlDate(date time.Time) string {
 	return "'" + date.Format("2006-01-02") + "'"
 }
@@ -207,6 +215,7 @@ func (s *SqlCommand) RenderQuery(parameters map[string]interface{}) (string, err
 	t2.Funcs(template.FuncMap{
 		"join":        strings.Join,
 		"sqlStringIn": sqlStringIn,
+		"sqlIntIn":    sqlIntIn,
 		"sqlIn":       sqlIn,
 		"sqlDate":     sqlDate,
 		"sqlDateTime": sqlDateTime,

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -170,8 +170,8 @@ type SqlCommand struct {
 	Arguments []*SqlParameter `yaml:"arguments"`
 	Query     string          `yaml:"query"`
 
-	Parents []string
-	Source  string
+	Parents []string `yaml:",omitempty"`
+	Source  string   `yaml:",omitempty"`
 }
 
 func (sc *SqlCommand) IsValid() bool {
@@ -387,7 +387,8 @@ func LoadSqlCommandsFromEmbedFS(f embed.FS, dir string, cmdRoot string) ([]*SqlC
 					}()
 
 					if err != nil {
-						return nil, nil, err
+						_, _ = fmt.Fprintf(os.Stderr, "Could not load command or alias from file %s: %s\n", fileName, err)
+						continue
 					} else {
 						aliases = append(aliases, alias)
 					}
@@ -471,7 +472,9 @@ func LoadSqlCommandsFromDirectory(dir string, cmdRoot string) ([]*SqlCommand, []
 					}()
 
 					if err != nil {
-						return nil, nil, err
+						_, _ = fmt.Fprintf(os.Stderr, "Could not load command or alias from file %s: %s", fileName, err)
+						continue
+
 					} else {
 						aliases = append(aliases, alias)
 					}

--- a/pkg/viper.go
+++ b/pkg/viper.go
@@ -1,0 +1,66 @@
+package pkg
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+)
+
+func OpenDatabaseFromViper() (*sqlx.DB, error) {
+	// Load the configuration values from the configuration file
+	host := viper.GetString("host")
+	database := viper.GetString("database")
+	user := viper.GetString("user")
+	password := viper.GetString("password")
+	port := viper.GetInt("port")
+	schema := viper.GetString("schema")
+	connectionType := viper.GetString("type")
+	dsn := viper.GetString("dsn")
+	driver := viper.GetString("driver")
+	useDbtProfiles := viper.GetBool("use-dbt-profiles")
+	dbtProfilesPath := viper.GetString("dbt-profiles-path")
+	dbtProfile := viper.GetString("dbt-profile")
+
+	// TODO(2022-12-18, manuel) This is where we would add support for DSN/Driver loading
+	// See https://github.com/wesen/sqleton/issues/21
+	_ = dsn
+	_ = driver
+
+	var source *Source
+
+	if useDbtProfiles {
+
+		sources, err := ParseDbtProfiles(dbtProfilesPath)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range sources {
+			if s.Name == dbtProfile {
+				source = s
+				break
+			}
+		}
+
+		if source == nil {
+			return nil, errors.Errorf("Source %s not found", dbtProfile)
+		}
+	} else {
+		source = &Source{
+			Type:     connectionType,
+			Hostname: host,
+			Port:     port,
+			Username: user,
+			Password: password,
+			Database: database,
+			Schema:   schema,
+		}
+	}
+
+	db, err := sqlx.Connect(source.Type, source.ToConnectionString())
+
+	// TODO(2022-12-18, manuel): this is where we would add support for a ro connection
+	// https://github.com/wesen/sqleton/issues/24
+
+	return db, err
+}


### PR DESCRIPTION
This adds support for simple alias definition that 
allow the creation of new cobra commands with preset flags for their parent command.

- :sparkles: Add a first pass at aliases, sadly incomplete
- :sparkles: Add create-alias command
- :art: Use a rougher approach to aliases
- :art: :memo: :poop: Add note to myself about the best way to capture arguments in aliases
- :memo: Add documentation about creating aliases
