### PR TITLE
Fix ordering of columns (now respects renames, and DB ordering)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tj/go-naturaldate v1.3.0
-	github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f
+	github.com/wesen/glazed v0.1.1-0.20221229030004-25de050da715
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tj/go-naturaldate v1.3.0
-	github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f
+	github.com/wesen/glazed v0.1.1-0.20221229025002-e5fe2b9d5f4a
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tj/go-naturaldate v1.3.0
-	github.com/wesen/glazed v0.1.1-0.20221229025002-e5fe2b9d5f4a
+	github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 h1:NSWpaDaurcAJY7PkL8Xt0
 github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-naturaldate v1.3.0 h1:OgJIPkR/Jk4bFMBLbxZ8w+QUxwjqSvzd9x+yXocY4RI=
 github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmytQs8d8hKk=
-github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f h1:m7GPDWA0MHLVRNmv6pKr2hYYu/shu686edHi/O3eGRg=
-github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f/go.mod h1:eu4PqXPZS6PInDV5/6ED/DIZnFvv2LKxXWheE47Myb8=
+github.com/wesen/glazed v0.1.1-0.20221229030004-25de050da715 h1:pYtIGwpYzpy3T+SCl1bQtpRcO+yRW7bY1HKTAqelwcg=
+github.com/wesen/glazed v0.1.1-0.20221229030004-25de050da715/go.mod h1:eu4PqXPZS6PInDV5/6ED/DIZnFvv2LKxXWheE47Myb8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/tj/go-naturaldate v1.3.0 h1:OgJIPkR/Jk4bFMBLbxZ8w+QUxwjqSvzd9x+yXocY4
 github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmytQs8d8hKk=
 github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f h1:m7GPDWA0MHLVRNmv6pKr2hYYu/shu686edHi/O3eGRg=
 github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f/go.mod h1:eu4PqXPZS6PInDV5/6ED/DIZnFvv2LKxXWheE47Myb8=
+github.com/wesen/glazed v0.1.1-0.20221229025002-e5fe2b9d5f4a h1:wa2nvoySTmskrwz5IuVDukbZOVsDWSWCuwfwrIA+2hM=
+github.com/wesen/glazed v0.1.1-0.20221229025002-e5fe2b9d5f4a/go.mod h1:eu4PqXPZS6PInDV5/6ED/DIZnFvv2LKxXWheE47Myb8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,6 @@ github.com/tj/go-naturaldate v1.3.0 h1:OgJIPkR/Jk4bFMBLbxZ8w+QUxwjqSvzd9x+yXocY4
 github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmytQs8d8hKk=
 github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f h1:m7GPDWA0MHLVRNmv6pKr2hYYu/shu686edHi/O3eGRg=
 github.com/wesen/glazed v0.1.1-0.20221228210039-b35ea18e855f/go.mod h1:eu4PqXPZS6PInDV5/6ED/DIZnFvv2LKxXWheE47Myb8=
-github.com/wesen/glazed v0.1.1-0.20221229025002-e5fe2b9d5f4a h1:wa2nvoySTmskrwz5IuVDukbZOVsDWSWCuwfwrIA+2hM=
-github.com/wesen/glazed v0.1.1-0.20221229025002-e5fe2b9d5f4a/go.mod h1:eu4PqXPZS6PInDV5/6ED/DIZnFvv2LKxXWheE47Myb8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"github.com/wesen/glazed/pkg/cli"
-	"github.com/wesen/glazed/pkg/middlewares"
 	"gopkg.in/yaml.v3"
 	"io"
 	"os"
@@ -273,10 +272,7 @@ func processQueryResults(rows *sqlx.Rows, gp *cli.GlazeProcessor) error {
 		return errors.Wrapf(err, "Could not get columns")
 	}
 
-	cols = gp.RenameColumns(cols)
-	gp.AddTableMiddlewares(middlewares.NewReorderColumnOrderMiddleware(cols))
-	// add support for renaming columns (at least to lowercase)
-	// https://github.com/wesen/glazed/issues/27
+	gp.OutputFormatter().SetColumnOrder(cols)
 
 	for rows.Next() {
 		row := map[string]interface{}{}

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -273,7 +273,8 @@ func processQueryResults(rows *sqlx.Rows, gp *cli.GlazeProcessor) error {
 		return errors.Wrapf(err, "Could not get columns")
 	}
 
-	gp.OutputFormatter().AddTableMiddleware(middlewares.NewReorderColumnOrderMiddleware(cols))
+	cols = gp.RenameColumns(cols)
+	gp.AddTableMiddlewares(middlewares.NewReorderColumnOrderMiddleware(cols))
 	// add support for renaming columns (at least to lowercase)
 	// https://github.com/wesen/glazed/issues/27
 


### PR DESCRIPTION
- :art: Add the start of implementing keeping track of renames in GlazeProcessor
- :art: Add the better way to set the column orders after querying the DB:
- :arrow_up: Bump glazed
